### PR TITLE
Add a `DaemonBuilder` to clean up `Daemon` construction

### DIFF
--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_DEPLOYMENT: &str = "default";
 #[derive(Clone, Default)]
 /// Create [`Daemon`] through [`DaemonBuilderBuilder`]
 /// ## Example
-/// ```ignore
+/// ```no_run
 ///     use boot_core::{DaemonBuilder, networks};
 ///
 ///     let daemon = DaemonBuilder::default()

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -1,10 +1,10 @@
 use std::rc::Rc;
 
 use ibc_chain_registry::chain::ChainData;
-use secp256k1::All;
+
 use tokio::runtime::Handle;
 
-use crate::{Daemon, DaemonError, Wallet};
+use crate::{Daemon, DaemonError};
 
 use super::{sender::Sender, state::DaemonState};
 

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -62,7 +62,8 @@ impl DaemonBuilder {
         self.handle = Some(handle.clone());
         self
     }
-
+    
+    /// Set the mnemonic to use with this chain. 
     pub fn mnemonic(&mut self, mnemonic: impl ToString) -> &mut Self {
         self.mnemonic = Some(mnemonic.to_string());
         self

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -1,0 +1,98 @@
+use std::rc::Rc;
+
+use ibc_chain_registry::chain::ChainData;
+use secp256k1::All;
+use tokio::runtime::Handle;
+
+use crate::{Daemon, DaemonError, Wallet};
+
+use super::{sender::Sender, state::DaemonState};
+
+pub const DEFAULT_DEPLOYMENT: &str = "default";
+
+#[derive(Clone, Default)]
+/// Create [`Daemon`] through [`DaemonBuilderBuilder`]
+/// ## Example
+/// ```
+///     use boot_core::{DaemonBuilder, networks};
+///
+///     let daemon = DaemonBuilder::default()
+///         .network(networks::LOCAL_JUNO)
+///         .deployment_id("v0.1.0")
+///         .build()
+///         .unwrap();
+/// ```
+pub struct DaemonBuilder {
+    // # Required
+    pub(crate) chain: Option<ChainData>,
+    pub(crate) handle: Option<tokio::runtime::Handle>,
+    // # Optional
+    pub(crate) deployment_id: Option<String>,
+    /// Optional wallet mnemonic
+    pub(crate) mnemonic: Option<String>,
+}
+
+impl DaemonBuilder {
+    /// Set the chain the daemon will connect to
+    pub fn chain(&mut self, chain: impl Into<ChainData>) -> &mut Self {
+        self.chain = Some(chain.into());
+        self
+    }
+
+    /// Set the deployment id to use for the daemon interactions
+    /// Defaults to `default`
+    pub fn deployment_id(&mut self, deployment_id: impl Into<String>) -> &mut Self {
+        self.deployment_id = Some(deployment_id.into());
+        self
+    }
+
+    /// Set the tokio runtime handle to use for the daemon
+    /// Defaults to the current runtime
+    ///
+    /// ## Example
+    /// ```no_run
+    /// use boot_core::Daemon;
+    /// use tokio::runtime::Runtime;
+    /// let rt = Runtime::new().unwrap();
+    /// let daemon = Daemon::builder()
+    ///     .handle(rt.handle())
+    ///     // ...
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn handle(&mut self, handle: &tokio::runtime::Handle) -> &mut Self {
+        self.handle = Some(handle.clone());
+        self
+    }
+
+    pub fn mnemonic(&mut self, mnemonic: impl ToString) -> &mut Self {
+        self.mnemonic = Some(mnemonic.to_string());
+        self
+    }
+
+    /// Build a daemon
+    pub fn build(&self) -> Result<Daemon, DaemonError> {
+        let chain = self
+            .chain
+            .clone()
+            .ok_or(DaemonError::BuilderMissing("chain information".into()))?;
+        let rt_handle = self.handle.clone().unwrap_or(Handle::current());
+        let deployment_id = self
+            .deployment_id
+            .clone()
+            .unwrap_or(DEFAULT_DEPLOYMENT.to_string());
+        let state = Rc::new(rt_handle.block_on(DaemonState::new(chain, deployment_id))?);
+        // if mnemonic provided, use it. Else use env variables to retrieve mnemonic
+        let sender = if let Some(mnemonic) = &self.mnemonic {
+            Sender::from_mnemonic(&state, mnemonic)?
+        } else {
+            Sender::new(&state)?
+        };
+        let daemon = Daemon {
+            rt_handle,
+            state,
+            sender: Rc::new(sender),
+        };
+        Ok(daemon)
+    }
+}

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -76,7 +76,7 @@ impl DaemonBuilder {
             .chain
             .clone()
             .ok_or(DaemonError::BuilderMissing("chain information".into()))?;
-        let rt_handle = self.handle.clone().unwrap_or(Handle::current());
+        let rt_handle = self.handle.clone().ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
         let deployment_id = self
             .deployment_id
             .clone()

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -2,8 +2,6 @@ use std::rc::Rc;
 
 use ibc_chain_registry::chain::ChainData;
 
-use tokio::runtime::Handle;
-
 use crate::{Daemon, DaemonError};
 
 use super::{sender::Sender, state::DaemonState};
@@ -13,11 +11,11 @@ pub const DEFAULT_DEPLOYMENT: &str = "default";
 #[derive(Clone, Default)]
 /// Create [`Daemon`] through [`DaemonBuilderBuilder`]
 /// ## Example
-/// ```
+/// ```ignore
 ///     use boot_core::{DaemonBuilder, networks};
 ///
 ///     let daemon = DaemonBuilder::default()
-///         .network(networks::LOCAL_JUNO)
+///         .chain(networks::LOCAL_JUNO)
 ///         .deployment_id("v0.1.0")
 ///         .build()
 ///         .unwrap();

--- a/boot-core/src/daemon/builder.rs
+++ b/boot-core/src/daemon/builder.rs
@@ -62,8 +62,8 @@ impl DaemonBuilder {
         self.handle = Some(handle.clone());
         self
     }
-    
-    /// Set the mnemonic to use with this chain. 
+
+    /// Set the mnemonic to use with this chain.
     pub fn mnemonic(&mut self, mnemonic: impl ToString) -> &mut Self {
         self.mnemonic = Some(mnemonic.to_string());
         self
@@ -75,7 +75,10 @@ impl DaemonBuilder {
             .chain
             .clone()
             .ok_or(DaemonError::BuilderMissing("chain information".into()))?;
-        let rt_handle = self.handle.clone().ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
+        let rt_handle = self
+            .handle
+            .clone()
+            .ok_or(DaemonError::BuilderMissing("runtime handle".into()))?;
         let deployment_id = self
             .deployment_id
             .clone()

--- a/boot-core/src/daemon/channel.rs
+++ b/boot-core/src/daemon/channel.rs
@@ -66,14 +66,17 @@ impl DaemonChannel {
                 .await?
                 .into_inner();
 
-            // verify we are connected to the spected network
-            if node_info.default_node_info.as_ref().unwrap().network != chain_id.as_str() {
-                log::error!(
-                    "Network mismatch: connection:{} != config:{}",
-                    node_info.default_node_info.as_ref().unwrap().network,
-                    chain_id.as_str()
-                );
-                continue;
+            // local juno does not return a proper ChainId with epoch format
+            if ChainId::is_epoch_format(&node_info.default_node_info.as_ref().unwrap().network) {
+                // verify we are connected to the spected network
+                if node_info.default_node_info.as_ref().unwrap().network != chain_id.as_str() {
+                    log::error!(
+                        "Network mismatch: connection:{} != config:{}",
+                        node_info.default_node_info.as_ref().unwrap().network,
+                        chain_id.as_str()
+                    );
+                    continue;
+                }
             }
 
             // add endpoint to succesful connections

--- a/boot-core/src/daemon/channel.rs
+++ b/boot-core/src/daemon/channel.rs
@@ -96,7 +96,7 @@ mod tests {
     */
     use std::sync::Arc;
 
-    use crate::{instantiate_daemon_env, DaemonOptionsBuilder};
+    use crate::Daemon;
     use speculoos::prelude::*;
     use tokio::runtime::Runtime;
 
@@ -104,23 +104,18 @@ mod tests {
     fn no_connection() {
         let runtime = Arc::new(Runtime::new().unwrap());
 
-        let mut network = boot_core::networks::LOCAL_JUNO;
+        let mut chain = boot_core::networks::LOCAL_JUNO;
         let grpcs = &vec!["https://127.0.0.1:99999"];
-        network.grpc_urls = grpcs;
+        chain.grpc_urls = grpcs;
 
-        let options = DaemonOptionsBuilder::default()
-            .network(network)
+        let build_res = Daemon::builder()
+            .handle(runtime.handle())
+            .chain(chain)
             .deployment_id("v0.1.0")
-            .build()
-            .unwrap();
+            .build();
 
         asserting!("there is no GRPC connection")
-            .that(
-                &instantiate_daemon_env(&runtime, options)
-                    .err()
-                    .unwrap()
-                    .to_string(),
-            )
+            .that(&build_res.err().unwrap().to_string())
             .is_equal_to(String::from(
                 "Can not connect to any grpc endpoint that was provided.",
             ))

--- a/boot-core/src/daemon/channel.rs
+++ b/boot-core/src/daemon/channel.rs
@@ -125,23 +125,18 @@ mod tests {
     fn network_grpcs_list_is_empty() {
         let runtime = Arc::new(Runtime::new().unwrap());
 
-        let mut network = boot_core::networks::LOCAL_JUNO;
+        let mut chain = boot_core::networks::LOCAL_JUNO;
         let grpcs: &Vec<&str> = &vec![];
-        network.grpc_urls = grpcs;
+        chain.grpc_urls = grpcs;
 
-        let options = DaemonOptionsBuilder::default()
-            .network(network)
+        let build_res = Daemon::builder()
+            .handle(runtime.handle())
+            .chain(chain)
             .deployment_id("v0.1.0")
-            .build()
-            .unwrap();
+            .build();
 
         asserting!("GRPC list is empty")
-            .that(
-                &instantiate_daemon_env(&runtime, options)
-                    .err()
-                    .unwrap()
-                    .to_string(),
-            )
+            .that(&build_res.err().unwrap().to_string())
             .is_equal_to(String::from("The list of grpc endpoints is empty"))
     }
 }

--- a/boot-core/src/daemon/contract.rs
+++ b/boot-core/src/daemon/contract.rs
@@ -44,7 +44,7 @@ impl Contract<Daemon> {
     pub fn latest_is_uploaded(&self) -> Result<bool, BootError> {
         let latest_uploaded_code_id = self.code_id()?;
         let chain = self.get_chain();
-        let on_chain_hash = chain.runtime.block_on(
+        let on_chain_hash = chain.rt_handle.block_on(
             chain
                 .query::<CosmWasm>()
                 .code_id_hash(latest_uploaded_code_id),
@@ -72,7 +72,7 @@ impl Contract<Daemon> {
         let latest_uploaded_code_id = self.code_id()?;
         let chain = self.get_chain();
         let info = chain
-            .runtime
+            .rt_handle
             .block_on(chain.query::<CosmWasm>().contract_info(self.address()?))?;
         Ok(latest_uploaded_code_id == info.code_id)
     }

--- a/boot-core/src/daemon/core.rs
+++ b/boot-core/src/daemon/core.rs
@@ -3,7 +3,7 @@ use super::{
     cosmos_modules,
     error::DaemonError,
     queriers::{DaemonQuerier, Node},
-    sender::{Sender, Wallet},
+    sender::Wallet,
     state::{ChainKind, DaemonState},
     tx_resp::CosmTxResponse,
 };
@@ -23,10 +23,9 @@ use std::{
     fmt::Debug,
     rc::Rc,
     str::{from_utf8, FromStr},
-    sync::Arc,
     time::Duration,
 };
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Handle;
 
 #[derive(Clone)]
 /**

--- a/boot-core/src/daemon/core.rs
+++ b/boot-core/src/daemon/core.rs
@@ -1,9 +1,10 @@
 use super::{
+    builder::DaemonBuilder,
     cosmos_modules,
     error::DaemonError,
     queriers::{DaemonQuerier, Node},
     sender::{Sender, Wallet},
-    state::{ChainKind, DaemonOptions, DaemonState},
+    state::{ChainKind, DaemonState},
     tx_resp::CosmTxResponse,
 };
 use crate::{
@@ -25,37 +26,38 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::runtime::Runtime;
-
-pub fn instantiate_daemon_env(
-    runtime: &Arc<Runtime>,
-    options: DaemonOptions,
-) -> anyhow::Result<(Addr, Daemon)> {
-    let state = Rc::new(runtime.block_on(DaemonState::new(options))?);
-    let sender = Rc::new(Sender::new(&state)?);
-    let chain = Daemon::new(&sender, &state, runtime)?;
-    Ok((sender.address()?, chain))
-}
+use tokio::runtime::{Handle, Runtime};
 
 #[derive(Clone)]
+/**
+    Represents a connection to a chain.
+    Is constructed with the [DaemonBuilder].
+*/
 pub struct Daemon {
     pub sender: Wallet,
     pub state: Rc<DaemonState>,
-    pub runtime: Arc<Runtime>,
+    pub rt_handle: Handle,
 }
 
 impl Daemon {
-    pub fn new(
-        sender: &Wallet,
-        state: &Rc<DaemonState>,
-        runtime: &Arc<Runtime>,
-    ) -> anyhow::Result<Self> {
-        let instance = Self {
-            sender: sender.clone(),
-            state: state.clone(),
-            runtime: runtime.clone(),
-        };
-        Ok(instance)
+    /// Get the daemon builder
+    pub fn builder() -> DaemonBuilder {
+        DaemonBuilder::default()
+    }
+
+    /// set the deployment after daemon
+    // pub fn set_deployment(&mut self, deployment_id: impl Into<String>) -> Result<(), DaemonError> {
+    //     // This ensures that you don't change the deployment of any contract that has been used before.
+    //     // It reduces the probability of shooting yourself in the foot.
+    //     Rc::get_mut(&mut self.state)
+    //         .ok_or(DaemonError::SharedDaemonState)?
+    //         .set_deployment(deployment_id);
+    //     Ok(())
+    // }
+
+    /// Perform a query with a given querier
+    pub fn query<Querier: DaemonQuerier>(&self) -> Querier {
+        Querier::new(self.sender.channel())
     }
 
     async fn wait(&self) {
@@ -64,20 +66,6 @@ impl Daemon {
             ChainKind::Mainnet => tokio::time::sleep(Duration::from_secs(60)).await,
             ChainKind::Testnet => tokio::time::sleep(Duration::from_secs(30)).await,
         }
-    }
-
-    pub fn set_deployment(&mut self, deployment_id: impl Into<String>) -> Result<(), DaemonError> {
-        // This ensures that you don't change the deployment of any contract that has been used before.
-        // It reduces the probability of shooting yourself in the foot.
-        Rc::get_mut(&mut self.state)
-            .ok_or(DaemonError::SharedDaemonState)?
-            .set_deployment(deployment_id);
-        Ok(())
-    }
-
-    /// Perform a query with a given querier
-    pub fn query<Querier: DaemonQuerier>(&self) -> Querier {
-        Querier::new(self.sender.channel())
     }
 }
 
@@ -111,7 +99,7 @@ impl TxHandler for Daemon {
             funds: parse_cw_coins(coins)?,
         };
         let result = self
-            .runtime
+            .rt_handle
             .block_on(self.sender.commit_tx(vec![exec_msg], None))?;
         Ok(result)
     }
@@ -136,7 +124,7 @@ impl TxHandler for Daemon {
         };
 
         let result = self
-            .runtime
+            .rt_handle
             .block_on(sender.commit_tx(vec![init_msg], None))?;
         // let address = &result.get_attribute_from_logs("instantiate", "_contract_address")[0].1;
 
@@ -150,7 +138,7 @@ impl TxHandler for Daemon {
     ) -> Result<T, DaemonError> {
         let sender = &self.sender;
         let mut client = cosmos_modules::cosmwasm::query_client::QueryClient::new(sender.channel());
-        let resp = self.runtime.block_on(client.smart_contract_state(
+        let resp = self.rt_handle.block_on(client.smart_contract_state(
             cosmos_modules::cosmwasm::QuerySmartContractStateRequest {
                 address: contract_address.to_string(),
                 query_data: serde_json::to_vec(&query_msg)?,
@@ -173,7 +161,7 @@ impl TxHandler for Daemon {
             code_id: new_code_id,
         };
         let result = self
-            .runtime
+            .rt_handle
             .block_on(self.sender.commit_tx(vec![exec_msg], None))?;
         Ok(result)
     }
@@ -194,55 +182,65 @@ impl TxHandler for Daemon {
             instantiate_permission: None,
         };
         let result = self
-            .runtime
+            .rt_handle
             .block_on(sender.commit_tx(vec![store_msg], None))?;
 
         log::info!("Uploaded: {:?}", result.txhash);
 
         // Extra time-out to ensure contract code propagation
-        self.runtime.block_on(self.wait());
+        self.rt_handle.block_on(self.wait());
         Ok(result)
     }
 
     fn wait_blocks(&self, amount: u64) -> Result<(), DaemonError> {
-        let mut last_height = self.runtime.block_on(self.query::<Node>().block_height())?;
+        let mut last_height = self
+            .rt_handle
+            .block_on(self.query::<Node>().block_height())?;
         let end_height = last_height + amount;
 
         while last_height < end_height {
             // wait
-            self.runtime
+            self.rt_handle
                 .block_on(tokio::time::sleep(Duration::from_secs(4)));
 
             // ping latest block
-            last_height = self.runtime.block_on(self.query::<Node>().block_height())?;
+            last_height = self
+                .rt_handle
+                .block_on(self.query::<Node>().block_height())?;
         }
         Ok(())
     }
 
     fn wait_seconds(&self, secs: u64) -> Result<(), DaemonError> {
-        self.runtime
+        self.rt_handle
             .block_on(tokio::time::sleep(Duration::from_secs(secs)));
 
         Ok(())
     }
 
     fn next_block(&self) -> Result<(), DaemonError> {
-        let mut last_height = self.runtime.block_on(self.query::<Node>().block_height())?;
+        let mut last_height = self
+            .rt_handle
+            .block_on(self.query::<Node>().block_height())?;
         let end_height = last_height + 1;
 
         while last_height < end_height {
             // wait
-            self.runtime
+            self.rt_handle
                 .block_on(tokio::time::sleep(Duration::from_secs(4)));
 
             // ping latest block
-            last_height = self.runtime.block_on(self.query::<Node>().block_height())?;
+            last_height = self
+                .rt_handle
+                .block_on(self.query::<Node>().block_height())?;
         }
         Ok(())
     }
 
     fn block_info(&self) -> Result<cosmwasm_std::BlockInfo, DaemonError> {
-        let block = self.runtime.block_on(self.query::<Node>().latest_block())?;
+        let block = self
+            .rt_handle
+            .block_on(self.query::<Node>().latest_block())?;
         let since_epoch = block.header.time.duration_since(Time::unix_epoch())?;
         let time = cosmwasm_std::Timestamp::from_nanos(since_epoch.as_nanos() as u64);
         Ok(cosmwasm_std::BlockInfo {

--- a/boot-core/src/daemon/error.rs
+++ b/boot-core/src/daemon/error.rs
@@ -94,4 +94,6 @@ pub enum DaemonError {
     GRPCListIsEmpty,
     #[error("no wasm path provided for contract.")]
     MissingWasmPath,
+    #[error("daemon builder missing {0}")]
+    BuilderMissing(String),
 }

--- a/boot-core/src/daemon/error.rs
+++ b/boot-core/src/daemon/error.rs
@@ -103,4 +103,5 @@ pub enum DaemonError {
 impl DaemonError {
     pub fn ibc_err(msg: impl ToString) -> Self {
         Self::IbcError(msg.to_string())
+    }
 }

--- a/boot-core/src/daemon/mod.rs
+++ b/boot-core/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod channel;
 pub mod contract;
 pub mod core;

--- a/boot-core/src/daemon/sender.rs
+++ b/boot-core/src/daemon/sender.rs
@@ -31,8 +31,6 @@ pub struct Sender<C: Signing + Context> {
 
 impl Sender<All> {
     pub fn new(daemon_state: &Rc<DaemonState>) -> Result<Sender<All>, DaemonError> {
-        let secp = Secp256k1::new();
-
         // NETWORK_MNEMONIC_GROUP
         let mnemonic = env::var(daemon_state.kind.mnemonic_name()).unwrap_or_else(|_| {
             panic!(
@@ -41,24 +39,29 @@ impl Sender<All> {
             )
         });
 
-        // use deployment mnemonic if specified, else use default network mnemonic
+        Self::from_mnemonic(daemon_state, &mnemonic)
+    }
+
+    /// Construct a new Sender from a mnemonic
+    pub fn from_mnemonic(
+        daemon_state: &Rc<DaemonState>,
+        mnemonic: &str,
+    ) -> Result<Sender<All>, DaemonError> {
+        let secp = Secp256k1::new();
         let p_key: PrivateKey =
-            PrivateKey::from_words(&secp, &mnemonic, 0, 0, daemon_state.chain.coin_type)?;
+            PrivateKey::from_words(&secp, mnemonic, 0, 0, daemon_state.chain.coin_type)?;
 
         let cosmos_private_key = SigningKey::from_bytes(&p_key.raw_key()).unwrap();
-
         let sender = Sender {
             daemon_state: daemon_state.clone(),
             private_key: cosmos_private_key,
             secp,
         };
-
         log::info!(
             "Interacting with {} using address: {}",
             daemon_state.chain_id,
             sender.pub_addr_str()?
         );
-
         Ok(sender)
     }
 

--- a/boot-core/src/daemon/state.rs
+++ b/boot-core/src/daemon/state.rs
@@ -1,5 +1,5 @@
-use super::{builder::DaemonBuilder, error::DaemonError};
-use crate::{daemon::channel::DaemonChannel, error::BootError, state::StateInterface, Daemon};
+use super::error::DaemonError;
+use crate::{daemon::channel::DaemonChannel, error::BootError, state::StateInterface};
 use cosmrs::Denom;
 use cosmwasm_std::Addr;
 use ibc_chain_registry::chain::{Apis, ChainData as RegistryChainInfo, FeeToken, FeeTokens, Grpc};

--- a/boot-core/src/daemon/state.rs
+++ b/boot-core/src/daemon/state.rs
@@ -1,5 +1,5 @@
-use super::error::DaemonError;
-use crate::{daemon::channel::DaemonChannel, error::BootError, state::StateInterface};
+use super::{builder::DaemonBuilder, error::DaemonError};
+use crate::{daemon::channel::DaemonChannel, error::BootError, state::StateInterface, Daemon};
 use cosmrs::Denom;
 use cosmwasm_std::Addr;
 use ibc_chain_registry::chain::{Apis, ChainData as RegistryChainInfo, FeeToken, FeeTokens, Grpc};
@@ -7,36 +7,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{collections::HashMap, env, fs::File, path::Path, rc::Rc, str::FromStr};
 use tonic::transport::Channel;
-
-pub const DEFAULT_DEPLOYMENT: &str = "default";
-
-/// Create [`DaemonOptions`] through [`DaemonOptionsBuilder`]
-/// ## Example
-/// ```
-///     use boot_core::{DaemonOptionsBuilder, networks};
-///
-///     let options = DaemonOptionsBuilder::default()
-///         .network(networks::LOCAL_JUNO)
-///         .deployment_id("v0.1.0")
-///         .build()
-///         .unwrap();
-/// ```
-#[derive(derive_builder::Builder)]
-#[builder(pattern = "owned")]
-pub struct DaemonOptions {
-    #[builder(setter(into))]
-    network: RegistryChainInfo,
-    #[builder(setter(into, strip_option))]
-    #[builder(default)]
-    // #[builder(setter(strip_option))]
-    deployment_id: Option<String>,
-}
-
-impl DaemonOptions {
-    pub fn get_network(&self) -> RegistryChainInfo {
-        self.network.clone()
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct DaemonState {
@@ -62,17 +32,18 @@ pub struct DaemonState {
 }
 
 impl DaemonState {
-    pub async fn new(options: DaemonOptions) -> Result<DaemonState, DaemonError> {
-        let network: RegistryChainInfo = options.network;
-
-        if network.apis.grpc.is_empty() {
+    pub async fn new(
+        chain_info: RegistryChainInfo,
+        deployment_id: String,
+    ) -> Result<DaemonState, DaemonError> {
+        if chain_info.apis.grpc.is_empty() {
             return Err(DaemonError::GRPCListIsEmpty);
         }
 
-        log::info!("Found {} gRPC endpoints", network.apis.grpc.len());
+        log::info!("Found {} gRPC endpoints", chain_info.apis.grpc.len());
 
         // find working grpc channel
-        let grpc_channel = DaemonChannel::connect(&network.apis.grpc, &network.chain_id)
+        let grpc_channel = DaemonChannel::connect(&chain_info.apis.grpc, &chain_info.chain_id)
             .await?
             .unwrap();
 
@@ -80,7 +51,7 @@ impl DaemonState {
         let mut json_file_path = env::var("STATE_FILE").expect("STATE_FILE is not set");
 
         // if the network we are connecting is a local kind, add it to the fn
-        if network.network_type == ChainKind::Local.to_string() {
+        if chain_info.network_type == ChainKind::Local.to_string() {
             let name = Path::new(&json_file_path)
                 .file_stem()
                 .unwrap()
@@ -96,34 +67,29 @@ impl DaemonState {
         }
 
         // Try to get the standard fee token (probably shortest denom)
-        let shortest_denom_token =
-            network
-                .fees
-                .fee_tokens
-                .iter()
-                .fold(network.fees.fee_tokens[0].clone(), |acc, item| {
-                    if item.denom.len() < acc.denom.len() {
-                        item.clone()
-                    } else {
-                        acc
-                    }
-                });
+        let shortest_denom_token = chain_info.fees.fee_tokens.iter().fold(
+            chain_info.fees.fee_tokens[0].clone(),
+            |acc, item| {
+                if item.denom.len() < acc.denom.len() {
+                    item.clone()
+                } else {
+                    acc
+                }
+            },
+        );
 
         // build daemon state
         let state = DaemonState {
             json_file_path,
-            kind: ChainKind::from(network.network_type),
-            deployment_id: options
-                .deployment_id
-                .map(Into::into)
-                .unwrap_or_else(|| DEFAULT_DEPLOYMENT.into()),
+            kind: ChainKind::from(chain_info.network_type),
+            deployment_id,
             grpc_channel,
             chain: ChainInfoOwned {
-                network_id: network.chain_name.to_string(),
-                pub_address_prefix: network.bech32_prefix,
-                coin_type: network.slip44,
+                network_id: chain_info.chain_name.to_string(),
+                pub_address_prefix: chain_info.bech32_prefix,
+                coin_type: chain_info.slip44,
             },
-            chain_id: network.chain_id.to_string(),
+            chain_id: chain_info.chain_id.to_string(),
             gas_denom: Denom::from_str(&shortest_denom_token.denom).unwrap(),
             gas_price: shortest_denom_token.fixed_min_gas_price,
             lcd_url: None,

--- a/boot-core/src/lib.rs
+++ b/boot-core/src/lib.rs
@@ -33,12 +33,8 @@ pub use cw_multi_test::ContractWrapper;
 
 #[cfg(feature = "daemon")]
 pub use daemon::{
-    channel::DaemonChannel,
-    core::{instantiate_daemon_env, Daemon},
-    error::DaemonError,
-    networks, queriers,
-    state::{DaemonOptions, DaemonOptionsBuilder},
-    Wallet,
+    builder::DaemonBuilder, channel::DaemonChannel, core::Daemon, error::DaemonError, networks,
+    queriers, Wallet,
 };
 
 #[cfg(feature = "daemon")]

--- a/boot-core/src/lib.rs
+++ b/boot-core/src/lib.rs
@@ -40,15 +40,6 @@ pub use daemon::{
 #[cfg(feature = "daemon")]
 pub use ibc_chain_registry::{chain::ChainData as RegistryChainData, fetchable::Fetchable};
 
-#[deprecated(
-    since = "0.8.1",
-    note = "Phasing out the use of `BootEnvironment` in favor of `CwEnv`"
-)]
-/// Signals a supported execution environment
-pub trait BootEnvironment: TxHandler + Clone {}
-#[allow(deprecated)]
-impl<T: TxHandler + Clone> BootEnvironment for T {}
-
 /// Signals a supported execution environment for CosmWasm contracts
 pub trait CwEnv: TxHandler + Clone {}
 impl<T: TxHandler + Clone> CwEnv for T {}

--- a/boot-core/src/mock/core.rs
+++ b/boot-core/src/mock/core.rs
@@ -288,7 +288,7 @@ mod test {
     use serde::Serialize;
     use speculoos::prelude::*;
 
-    use crate::{mock::core::*, ContractCodeReference, TxHandler};
+    use crate::{mock::core::*, TxHandler};
 
     const SENDER: &str = "cosmos123";
     const BALANCE_ADDR: &str = "cosmos456";

--- a/boot-core/tests/common/channel.rs
+++ b/boot-core/tests/common/channel.rs
@@ -1,20 +1,21 @@
-use boot_core::{networks, DaemonChannel, DaemonOptions, DaemonOptionsBuilder};
+use boot_core::{networks, DaemonChannel};
 
+use ibc_chain_registry::chain::Grpc;
+use ibc_relayer_types::core::ics24_host::identifier::ChainId;
 use speculoos::{asserting, prelude::OptionAssertions};
 
 #[allow(unused)]
 pub async fn build_channel() -> Option<tonic::transport::Channel> {
-    let options: DaemonOptions = DaemonOptionsBuilder::default()
-        .network(networks::LOCAL_JUNO)
-        .deployment_id("v0.1.0")
-        .build()
-        .unwrap();
+    let network = networks::LOCAL_JUNO;
 
-    let network = options.get_network();
+    let grpcs: Vec<Grpc> = vec![Grpc {
+        address: network.grpc_urls[0].into(),
+        provider: None,
+    }];
 
-    let channel = DaemonChannel::connect(&network.apis.grpc, &network.chain_id)
-        .await
-        .unwrap();
+    let chain: ChainId = ChainId::new(network.chain_id.to_owned(), 1);
+
+    let channel = DaemonChannel::connect(&grpcs, &chain).await.unwrap();
 
     asserting!("channel connection is succesful")
         .that(&channel)

--- a/boot-core/tests/common/contract.rs
+++ b/boot-core/tests/common/contract.rs
@@ -13,9 +13,7 @@ use boot_core::{networks::LOCAL_JUNO, Contract, ContractWrapper, Daemon};
 
 const CW20_CONTRACT_WASM: &str = "/../boot-cw-plus/cw-artifacts/cw20_base.wasm";
 
-pub fn start() -> (cosmwasm_std::Addr, Contract<Daemon>) {
-    let runtime = Arc::new(Runtime::new().unwrap());
-
+pub fn start(runtime: &Arc<Runtime>) -> (cosmwasm_std::Addr, Contract<Daemon>) {
     let id = Id::new();
 
     let daemon = Daemon::builder()

--- a/boot-core/tests/common/contract.rs
+++ b/boot-core/tests/common/contract.rs
@@ -9,10 +9,7 @@ struct DeployId(());
 
 type Id = IdT<DeployId>;
 
-use boot_core::{
-    instantiate_daemon_env, networks::LOCAL_JUNO, Contract, ContractWrapper, Daemon,
-    DaemonOptionsBuilder,
-};
+use boot_core::{networks::LOCAL_JUNO, Contract, ContractWrapper, Daemon};
 
 const CW20_CONTRACT_WASM: &str = "/../boot-cw-plus/cw-artifacts/cw20_base.wasm";
 
@@ -21,20 +18,20 @@ pub fn start() -> (cosmwasm_std::Addr, Contract<Daemon>) {
 
     let id = Id::new();
 
-    let options = DaemonOptionsBuilder::default()
-        .network(LOCAL_JUNO)
-        .deployment_id(format!("{}", id))
+    let daemon = Daemon::builder()
+        .chain(LOCAL_JUNO)
+        .handle(runtime.handle())
         .build()
         .unwrap();
 
-    let (sender, chain) = instantiate_daemon_env(&runtime, options).unwrap();
+    let sender = daemon.sender.address().unwrap();
 
     // create contract base configuration
     let crate_path = env!("CARGO_MANIFEST_DIR");
     let wasm_path = format!("{}{}", crate_path, CW20_CONTRACT_WASM);
     log::info!("Using wasm path {}", wasm_path);
 
-    let contract = Contract::new(format!("cw-plus:cw20_base:{}", id), chain)
+    let contract = Contract::new(format!("cw-plus:cw20_base:{}", id), daemon)
         .with_mock(Box::new(
             ContractWrapper::new_with_empty(
                 cw20_base::contract::execute,

--- a/boot-core/tests/contract.rs
+++ b/boot-core/tests/contract.rs
@@ -2,17 +2,22 @@
     Daemon tests
 */
 mod common;
+use std::sync::Arc;
+
 use boot_core::contract;
 use speculoos::prelude::*;
 
 use cw20_base::msg::*;
+use tokio::runtime::Runtime;
 
 #[contract(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
 pub struct Cw20Base;
 
 #[test]
 fn general() {
-    let (sender, mut contract) = common::contract::start();
+    let runtime = Arc::new(Runtime::new().unwrap());
+
+    let (sender, mut contract) = common::contract::start(&runtime);
 
     // upload contract
     let upload_res = contract.upload();

--- a/boot-core/tests/daemon_contract.rs
+++ b/boot-core/tests/daemon_contract.rs
@@ -2,13 +2,18 @@
     Daemon contract general tests
 */
 mod common;
+use std::sync::Arc;
+
 use cosmwasm_std::Addr;
 
 use speculoos::prelude::*;
+use tokio::runtime::Runtime;
 
 #[test]
 fn general() {
-    let (sender, mut contract) = common::contract::start();
+    let runtime = Arc::new(Runtime::new().unwrap());
+
+    let (sender, mut contract) = common::contract::start(&runtime);
 
     asserting!("address is not present")
         .that(&contract.address())

--- a/boot-core/tests/querier.rs
+++ b/boot-core/tests/querier.rs
@@ -36,7 +36,9 @@ fn general() {
 #[test]
 fn simulate_tx() {
     let rt = Arc::new(Runtime::new().unwrap());
+
     let channel = rt.block_on(build_channel()).unwrap();
+
     let node = Node::new(channel.clone());
 
     let exec_msg = cw20_base::msg::ExecuteMsg::Mint {
@@ -80,7 +82,7 @@ fn contract_info() {
     let channel = rt.block_on(build_channel()).unwrap();
     let cosm_wasm = CosmWasm::new(channel.clone());
 
-    let (sender, mut contract) = common::contract::start();
+    let (sender, mut contract) = common::contract::start(&rt);
 
     let _ = contract.upload();
 


### PR DESCRIPTION
This PR aims to clean up the creation and configuration of the `Daemon` struct. 

After doing some research on async programming I had a couple realizations that will help us scale this library. But before we get there we need to improve the way we handle these objects. To do this I got rid of the `DaemonOptions` object and and created a `DaemonBuilder` instead. It can be used as: 

## In `sync` context
```rust
let runtime = Arc::new(Runtime::new().unwrap());
let daemon: Daemon = Daemon::builder()
  .handle(runtime.handle())
  .chain(chain)
  .build()?;
```

~~## In `async` context~~
**Note** This does not work as the `block_on` functions that are called in the daemon panic when called in async context. 
```rust
let daemon: Daemon = Daemon::builder()
  .chain(chain)
  // No need to specify the runtime handle yourself !! 
  .build()?;
```
## Changes

- Replace the `Arc<Runtime>` with a `Handle` to improve async usability. 
- Add a `DaemonBuilder` and methods to create it
- Add a `from_mnemonic` function to `Sender` to allow for custom mnemonics in the daemon configuration. 